### PR TITLE
Gentle write

### DIFF
--- a/anyloadump/loadump.py
+++ b/anyloadump/loadump.py
@@ -83,7 +83,7 @@ class Loadumper():
     generalized [load|dump]s? function
     """
     def loadump(self, open_mode: OpenMode, *,
-                obj=None, s=None, filename=None, fmt=None, encoding=None, errors=None, buffering=None, **kwargs):
+                obj=None, s=None, filename=None, fmt=None, encoding=None, errors=None, buffering=None, _retry=False, **kwargs):
         # load method precedes loads
         if obj is not None:
             if s is not None:
@@ -96,7 +96,22 @@ class Loadumper():
             codecs_kwargs = \
                 {k:v for k,v in dict(mode=mode, encoding=encoding, errors=errors, buffering=buffering).items() \
                     if v is not None}
-            with codecs.open(filename=filename, **codecs_kwargs) as fp:
-                args = (fp,) if open_mode == OpenMode.READ else (obj, fp)
-                return self._invoke(open_mode=open_mode, filename=filename, fmt=fmt)(*args, **kwargs)
-
+            try:
+                with codecs.open(filename=filename, **codecs_kwargs) as fp:
+                    args = (fp,) if open_mode == OpenMode.READ else (obj, fp)
+                    return self._invoke(open_mode=open_mode, filename=filename, fmt=fmt)(*args, **kwargs)
+            except FileNotFoundError:
+                if _retry or os.path.exists(os.path.dirname(filename)):
+                    raise
+                os.makedirs(os.path.dirname(filename), exist_ok=True)
+                return self.loadump(
+                    open_mode,
+                    obj=obj,
+                    s=s,
+                    filename=filename,
+                    fmt=fmt,
+                    encoding=encoding,
+                    errors=errors,
+                    buffering=buffering,
+                    _retry=True, **kwargs
+                )

--- a/anyloadump/loadump.py
+++ b/anyloadump/loadump.py
@@ -103,6 +103,8 @@ class Loadumper():
             except FileNotFoundError:
                 if _retry or os.path.exists(os.path.dirname(filename)):
                     raise
+                if open_mode == OpenMode.READ:
+                    raise
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
                 return self.loadump(
                     open_mode,

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -60,3 +60,18 @@ class DumpTests(unittest.TestCase):
 
     def test_adumps(self):
         pass
+
+
+class NonExistendPathDumpTests(unittest.TestCase):
+    def test_dump_directory_is_notfound_when_created(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storedir = os.path.join(tmpdir, "store")
+            self.assertFalse(os.path.exists(storedir))
+
+            data = {"x": 1}
+            ald.dump(data, os.path.join(storedir, "data.json"))
+
+            self.assertTrue(os.path.exists(storedir))
+            loaded = ald.load(os.path.join(storedir, "data.json"))
+            self.assertEqual(data, loaded)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -47,3 +47,14 @@ class LoadTests(unittest.TestCase):
         b = pickle.dumps(sample)
         res = ald.loads(b, fmt="pickle")
         self.assertEqual(res, sample)
+
+
+class NonExistendPathLoadTests(unittest.TestCase):
+    def test_dump_directory_is_notfound_when_created(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            storedir = os.path.join(tmpdir, "store")
+            self.assertFalse(os.path.exists(storedir))
+
+            with self.assertRaises(FileNotFoundError):
+                ald.load(os.path.join(storedir, "data.json"))


### PR DESCRIPTION
more user-friendly behavior.

When dumping file, the dumped file's directory is not found, then created it.
(but on loading, FileNotFoundError is raised)